### PR TITLE
Add off-center counter button to signup page

### DIFF
--- a/app/components/assistant-ui/thread.tsx
+++ b/app/components/assistant-ui/thread.tsx
@@ -95,7 +95,7 @@ const ThreadWelcome: FC = () => {
               exit={{ opacity: 0, y: 10 }}
               className="aui-thread-welcome-message-motion-1 text-2xl font-semibold absolute top-[5%] left-1/2 -translate-x-1/2 text-center"
             >
-              Welcome to the Chatbot
+              Welcome to the Researcher 🧠
             </m.div>
             {/*<m.div
               initial={{ opacity: 0, y: 10 }}

--- a/app/routes/login.tsx
+++ b/app/routes/login.tsx
@@ -3,7 +3,7 @@ import { LoginForm } from "~/components/login-form"
 export default function LoggingIn() {
   return (
     <div>
-      <h1 className="text-center pt-8 text-4xl">Welcome to the Chatbot!</h1>
+      <h1 className="text-center pt-8 text-4xl">Welcome to the Researcher! 🧠</h1>
       <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 flex min-h-svh w-full items-center justify-center p-6 md:p-10">
         <div className="w-full max-w-sm">
           <LoginForm />

--- a/app/routes/login.tsx
+++ b/app/routes/login.tsx
@@ -3,7 +3,7 @@ import { LoginForm } from "~/components/login-form"
 export default function LoggingIn() {
   return (
     <div>
-      <h1 className="text-center pt-8 text-4xl">Welcome to the Researcher! 🧠</h1>
+      <h1 className="text-center pt-8 text-4xl">Welcome to the Researcher 🧠!</h1>
       <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 flex min-h-svh w-full items-center justify-center p-6 md:p-10">
         <div className="w-full max-w-sm">
           <LoginForm />

--- a/app/routes/signup.tsx
+++ b/app/routes/signup.tsx
@@ -3,7 +3,7 @@ import { SignupForm } from "~/components/signup-form"
 export default function Signingup() {
   return (
     <div>
-      <h1 className="text-center pt-8 text-4xl">Welcome to the Chatbot!</h1>
+      <h1 className="text-center pt-8 text-4xl">Welcome to the Researcher! 🧠</h1>
       <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 flex min-h-svh w-full items-center justify-center p-6 md:p-10">
         <div className="w-full max-w-sm">
           <SignupForm />

--- a/app/routes/signup.tsx
+++ b/app/routes/signup.tsx
@@ -1,12 +1,26 @@
 import { SignupForm } from "~/components/signup-form"
+import { useState } from "react"
+import { Button } from "~/components/ui/button"
 
 export default function Signingup() {
+  const [count, setCount] = useState(0)
+
   return (
     <div>
       <h1 className="text-center pt-8 text-4xl">Welcome to the Researcher 🧠!</h1>
       <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 flex min-h-svh w-full items-center justify-center p-6 md:p-10">
         <div className="w-full max-w-sm">
           <SignupForm />
+        </div>
+      </div>
+
+      {/* Way off-center counter button */}
+      <div className="absolute" style={{ left: '85%', top: '15%' }}>
+        <div className="flex flex-col gap-2 items-center">
+          <div className="text-2xl font-bold">Count: {count}</div>
+          <Button onClick={() => setCount(count + 1)}>
+            Increment
+          </Button>
         </div>
       </div>
     </div>

--- a/app/routes/signup.tsx
+++ b/app/routes/signup.tsx
@@ -3,7 +3,7 @@ import { SignupForm } from "~/components/signup-form"
 export default function Signingup() {
   return (
     <div>
-      <h1 className="text-center pt-8 text-4xl">Welcome to the Researcher! 🧠</h1>
+      <h1 className="text-center pt-8 text-4xl">Welcome to the Researcher 🧠!</h1>
       <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 flex min-h-svh w-full items-center justify-center p-6 md:p-10">
         <div className="w-full max-w-sm">
           <SignupForm />


### PR DESCRIPTION
## Summary
- Added an increment counter button to the signup page
- Button is positioned way off-center (left: 85%, top: 15%)
- Counter displays the current count and increments when clicked

## Test plan
- [x] Created count_button branch
- [x] Added counter button with state management
- [x] Positioned button off-center as requested
- [x] Tested in Chrome - button increments correctly (0 → 1 → 2)
- [x] Verified UI displays properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)